### PR TITLE
chore: cleanup imports and readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-08-19
+### Added
+
+### Changed
+- Removed wrong import package `path/filepath`
+- Removed placeholder repo url in english readme
+- Removed typo in readme
+
 ## [1.0.0] - 2025-08-19
 ### Added
 - Full **interactive mode** for all parameters (output path, risk acceptance, vault picker, password, layout, masking, search).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # onepw-pdf-export
 
-**Deutsch | [English](#english)**
-
----
-
 ## 🇩🇪 Deutsch
 
 **[Deutsch 🇩🇪](#deutsch-) | [English 🇬🇧](#english-)**
@@ -69,11 +65,23 @@ Verwende es **nur für dich selbst** und behandle die PDF-Datei mit höchster Vo
 **Interaktiv:** Wenn du Flags weglässt, fragt das Tool **ALLE Parameter** ab (Ausgabedatei, Risikoakzeptanz, Tresor-Auswahl, Passwort, Layout, Maskierung, Suche). Während des Exports siehst du einen **Spinner/Fortschritt**.
 
 
-#### Standard (op) – ohne Subcommand
+#### Standard via 1Password CLI
+
+### Login to 1Password CLI (Siehe Requirements)
 ```bash
 op signin
-./onepw-pdf-export live --out my-vault.pdf --i-understand-the-risk
-# fragt nach PDF-Passwort (verdeckt, mit Wiederholung)
+```
+
+### Starten (interaktiv)
+```bash
+./onepw-pdf-export live
+# prompts for all details
+```
+
+### CLI paramter
+```bash
+./onepw-pdf-export ./onepw-pdf-export --out my-vault.pdf --i-understand-the-risk
+# prompts for password
 ```
 
 #### CSV
@@ -177,7 +185,7 @@ Use it **only for yourself** and treat the resulting PDF with extreme caution. I
 
 3. **Build this repo**
    ```bash
-   git clone https://github.com/example/onepw-pdf-export.git
+   git clone git@github.com:ClemensRau1337/onepw-pdf-export.git
    cd onepw-pdf-export
    go mod tidy
    go build -o onepw-pdf-export ./
@@ -191,10 +199,22 @@ Use it **only for yourself** and treat the resulting PDF with extreme caution. I
 
 
 #### Live via 1Password CLI
+
+### Login to 1Password CLI (See Requirements)
 ```bash
 op signin
-./onepw-pdf-export live --out my-vault.pdf --i-understand-the-risk
-# prompts for PDF password (hidden, confirmed)
+```
+
+### Starten (interaktiv)
+```bash
+./onepw-pdf-export live
+# prompts for all details
+```
+
+### CLI paramter
+```bash
+./onepw-pdf-export ./onepw-pdf-export --out my-vault.pdf --i-understand-the-risk
+# prompts for password
 ```
 
 #### CSV

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/jung-kurt/gofpdf v1.16.2
 	golang.org/x/term v0.23.0
 )
+
+require golang.org/x/sys v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
+github.com/jung-kurt/gofpdf v1.16.2 h1:jgbatWHfRlPYiK85qgevsZTHviWXKwB1TTiKdz5PtRc=
+github.com/jung-kurt/gofpdf v1.16.2/go.mod h1:1hl7y57EsiPAkLbOwzpzqgx1A30nQCk/YmFV8S2vmK0=
+github.com/phpdave11/gofpdi v1.0.7/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
+golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.23.0 h1:F6D4vR+EHoL9/sWAWgAR1H2DcHr4PareCbAaCo1RpuU=
+golang.org/x/term v0.23.0/go.mod h1:DgV24QBUrK6jhZXl+20l6UWznPlwAHm1Q1mGHtydmSk=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"path/filepath"
 
 	"golang.org/x/term"
 

--- a/pkg/onepux/onepux.go
+++ b/pkg/onepux/onepux.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/example/onepw-pdf-export/pkg/model"


### PR DESCRIPTION
- removed wrong import package `path/filepath`
- removed placeholder repo url in English readme
- fixed typo in readme